### PR TITLE
Enhance the k8s-keystone to support whitelist for some resources

### DIFF
--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -281,6 +281,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"developer"},
+                        DomainName:     {"Default"},
 		},
 	}
 	viewer := &user.DefaultInfo{
@@ -290,6 +291,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"demo"},
 			ProjectID:   {"ff9db8980cf24a74bc9dd796b6ce811f"},
 			Roles:       {"viewer"},
+                        DomainName:     {"Default"},
 		},
 	}
 	anotherviewer := &user.DefaultInfo{
@@ -299,6 +301,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"alt_demo"},
 			ProjectID:   {"cd08a539b7c845ddb92c5d08752101d1"},
 			Roles:       {"viewer"},
+                        DomainName:     {"Default"},
 		},
 	}
 	clusteradmin := &user.DefaultInfo{
@@ -307,6 +310,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"clusteradmin"},
+                        DomainName:     {"Default"},
 		},
 	}
 

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -2,32 +2,36 @@
   {
     "users": {
       "roles": ["developer"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
     "resource_permissions": {
-      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["*"],
-      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"]
+      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles']/['*']": ["*"],
+      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles']/['*']": ["get", "list"]
     }
   },
   {
     "users": {
       "roles": ["viewer"],
-      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"]
+      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"],
+      "domains": ["Default"]
     },
     "resource_permissions": {
-      "default/['*']": ["get", "list"]
+      "default/['*']/['*']": ["get", "list"]
     }
   },
   {
     "users": {
       "roles": ["clusteradmin"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
     "resource_permissions": {
-      "*/*": ["*"]
+      "*/*/*": ["*"]
     },
     "nonresource_permissions": {
       "/healthz": ["get", "post"]
     }
   }
 ]
+

--- a/pkg/identity/keystone/config.go
+++ b/pkg/identity/keystone/config.go
@@ -26,31 +26,33 @@ import (
 
 // Config configures a keystone webhook server
 type Config struct {
-	Address             string
-	CertFile            string
-	KeyFile             string
-	KeystoneURL         string
-	KeystoneCA          string
-	PolicyFile          string
-	PolicyConfigMapName string
-	SyncConfigFile      string
-	SyncConfigMapName   string
-	Kubeconfig          string
+	Address             	string
+	CertFile            	string
+	KeyFile             	string
+	KeystoneURL         	string
+	KeystoneCA          	string
+	PolicyFile          	string
+	PolicyConfigMapName 	string
+	SyncConfigFile      	string
+	SyncConfigMapName   	string
+	K8sPrivilegeResources	string
+	Kubeconfig          	string
 }
 
 // NewConfig returns a Config
 func NewConfig() *Config {
 	return &Config{
-		Address:             "0.0.0.0:8443",
-		CertFile:            os.Getenv("TLS_CERT_FILE"),
-		KeyFile:             os.Getenv("TLS_PRIVATE_KEY_FILE"),
-		KeystoneURL:         os.Getenv("OS_AUTH_URL"),
-		KeystoneCA:          os.Getenv("KEYSTONE_CA_FILE"),
-		PolicyFile:          os.Getenv("KEYSTONE_POLICY_FILE"),
-		PolicyConfigMapName: os.Getenv("KEYSTONE_POLICY_CONFIGMAP_NAME"),
-		SyncConfigFile:      os.Getenv("KEYSTONE_SYNC_CONFIG_FILE"),
-		SyncConfigMapName:   os.Getenv("KEYSTONE_SYNC_CONFIGMAP_NAME"),
-		Kubeconfig:          os.Getenv("KEYSTONE_KUBECONFIG_FILE"),
+		Address:             	"0.0.0.0:8443",
+		CertFile:            	os.Getenv("TLS_CERT_FILE"),
+		KeyFile:             	os.Getenv("TLS_PRIVATE_KEY_FILE"),
+		KeystoneURL:         	os.Getenv("OS_AUTH_URL"),
+		KeystoneCA:          	os.Getenv("KEYSTONE_CA_FILE"),
+		PolicyFile:          	os.Getenv("KEYSTONE_POLICY_FILE"),
+		PolicyConfigMapName: 	os.Getenv("KEYSTONE_POLICY_CONFIGMAP_NAME"),
+		SyncConfigFile:      	os.Getenv("KEYSTONE_SYNC_CONFIG_FILE"),
+		SyncConfigMapName:   	os.Getenv("KEYSTONE_SYNC_CONFIGMAP_NAME"),
+		K8sPrivilegeResources:	os.Getenv("K8S_PRIVILEGE_RESOURCES"),
+		Kubeconfig:          	os.Getenv("KEYSTONE_KUBECONFIG_FILE"),
 	}
 }
 
@@ -90,5 +92,6 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.PolicyConfigMapName, "policy-configmap-name", c.PolicyConfigMapName, "ConfigMap in kube-system namespace containing the policy configuration, the ConfigMap data must contain the key 'policies'")
 	fs.StringVar(&c.SyncConfigFile, "sync-config-file", c.SyncConfigFile, "File containing config values for data synchronization beetween Keystone and Kubernetes.")
 	fs.StringVar(&c.SyncConfigMapName, "sync-configmap-name", "", "ConfigMap in kube-system namespace containing config values for data synchronization beetween Keystone and Kubernetes.")
+	fs.StringVar(&c.K8sPrivilegeResources, "k8s-privilege-resources", "", "A conjunction of resourceType/resourceName in format '[\"resource/name\"]', these resources will be allowed exceptionally. This parameter is only available in V2.")
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "Kubeconfig file used to connect to Kubernetes API to get policy configmap. If the service is running inside the pod, this option is not necessary, will use in-cluster config instead.")
 }

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -475,7 +475,7 @@ func NewKeystoneAuth(c *Config) (*KeystoneAuth, error) {
 
 	keystoneAuth := &KeystoneAuth{
 		authn:     &Authenticator{keystoner: NewKeystoner(keystoneClient)},
-		authz:     &Authorizer{authURL: c.KeystoneURL, client: keystoneClient, pl: policy},
+		authz:     &Authorizer{authURL: c.KeystoneURL, client: keystoneClient, pl: policy, prvres: c.K8sPrivilegeResources},
 		syncer:    &Syncer{k8sClient: k8sClient, syncConfig: sc},
 		k8sClient: k8sClient,
 		config:    c,


### PR DESCRIPTION
This patch includes two feature.
1. domain support in users rule. Different domains with same project name
and role will has different policy after this change.

2. resource with specified name will be added to whitelist if specified in
argument "k8s-privilege-resources". In this situation, resources with
other names will be blacklisted. If you want to allow all resources,
you will need not specify the resources type in the user policy.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #EAS-43871

**Special notes for reviewers**:
image and policy file will be changed all at once

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
policy rule will differ to upstream V2 policy. you should specify project ans domains in the user section. The format of resource changes to "namespace/resource/name".
```
