### PR TITLE
Enhance the k8s-keystone to support whitelist for some resources

### DIFF
--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -281,6 +281,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"developer"},
+			DomainName:  {"Default"},
 		},
 	}
 	viewer := &user.DefaultInfo{
@@ -290,6 +291,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"demo"},
 			ProjectID:   {"ff9db8980cf24a74bc9dd796b6ce811f"},
 			Roles:       {"viewer"},
+			DomainName:  {"Default"},
 		},
 	}
 	anotherviewer := &user.DefaultInfo{
@@ -299,6 +301,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"alt_demo"},
 			ProjectID:   {"cd08a539b7c845ddb92c5d08752101d1"},
 			Roles:       {"viewer"},
+			DomainName:  {"Default"},
 		},
 	}
 	clusteradmin := &user.DefaultInfo{
@@ -307,6 +310,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"clusteradmin"},
+			DomainName:  {"Default"},
 		},
 	}
 

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -2,30 +2,33 @@
   {
     "users": {
       "roles": ["developer"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["*"],
-      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"]
-    }
+    "resource_permissions": [
+      {"!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']/['*']": ["*"]},
+      {"!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']/['*']": ["get", "list"]}
+    ]
   },
   {
     "users": {
       "roles": ["viewer"],
-      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"]
+      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "default/['*']": ["get", "list"]
-    }
+    "resource_permissions": [
+      {"default/['*']/['*']": ["get", "list"]}
+    ]
   },
   {
     "users": {
       "roles": ["clusteradmin"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "*/*": ["*"]
-    },
+    "resource_permissions": [
+      {"*/*/*": ["*"]}
+    ],
     "nonresource_permissions": {
       "/healthz": ["get", "post"]
     }

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -570,7 +570,7 @@ func createKubernetesClient(kubeConfig string) (*kubernetes.Clientset, error) {
 func createKeystoneClient(authURL string, caFile string) (*gophercloud.ServiceClient, error) {
 	// FIXME: Enable this check later
 	//if !strings.HasPrefix(authURL, "https") {
-	//	return nil, errors.New("Auth URL should be secure and start with https")
+	//      return nil, errors.New("Auth URL should be secure and start with https")
 	//}
 	var transport http.RoundTripper
 	if authURL == "" {

--- a/pkg/identity/keystone/policy.go
+++ b/pkg/identity/keystone/policy.go
@@ -29,7 +29,7 @@ type policy struct {
 
 	Match []policyMatch `json:"match"`
 
-	ResourcePermissionsSpec map[string][]string `json:"resource_permissions,omitempty"`
+	ResourcePermissionsSpec []map[string][]string `json:"resource_permissions,omitempty"`
 
 	NonResourcePermissionsSpec map[string][]string `json:"nonresource_permissions,omitempty"`
 


### PR DESCRIPTION
This patch includes two feature.
1. domain support in users rule. Different domains with same project name
and role will has different policy after this change.

2. to resourcesPermissions section, it is ordered right now.
In the front of the policy rule will have higher privilege to determine
the action permission.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
changes has been made on k8s-keystone-policy. You should read the example in the test.
```
